### PR TITLE
Revert "Update README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-# lab-github-actions
-
-[![Build Status](https://github.com/efergee/customers/actions/workflows/workflow.yml/badge.svg)](https://github.com/efergee/customers/actions)
-[![codecov](https://codecov.io/gh/efergee/customers/graph/badge.svg?token=NQMF0BD24D)](https://codecov.io/gh/efergee/customers)
-
 # Customers Service
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)


### PR DESCRIPTION
Reverts CSCI-GA-2820-SP25-001/customers#66

<img width="378" alt="image" src="https://github.com/user-attachments/assets/4b3056fd-cf0c-4cf0-b883-7029d1465226" />
 
the CI badge is not working as intended 
the codecov is from a separate issue, covered by Amalia, so not needed for now